### PR TITLE
Fix typo of the shebang

### DIFF
--- a/test/error/install.bats
+++ b/test/error/install.bats
@@ -1,4 +1,4 @@
-#!/usr/bin/evn bats
+#!/usr/bin/env bats
 
 @test "dvm install" {
   run dvm install

--- a/test/error/now-version.bats
+++ b/test/error/now-version.bats
@@ -1,4 +1,4 @@
-#!/usr/bin/evn bats
+#!/usr/bin/env bats
 
 @test "dvm now-version" {
   run dvm now-version

--- a/test/success/now-version.bats
+++ b/test/success/now-version.bats
@@ -1,4 +1,4 @@
-#!/usr/bin/evn bats
+#!/usr/bin/env bats
 
 @test "dvm now-version" {
   run dvm now-version


### PR DESCRIPTION
- `evn` looks typo for `env`
- So I changed it by the Perl one liner:
    - `perl -i -plE 's/#!\/usr\/bin\/evn/#!\/usr\/bin\/env/' **/*.*`